### PR TITLE
Fix inline `<script>` tag matching when spanning multiple lines

### DIFF
--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -20,7 +19,7 @@ public class Scanner {
      * Patterns identified in .jelly files
      */
     protected static final Map<String, Pattern> JELLY_PATTERNS = Map.of("Inline Event Handler", Pattern.compile("<[^>]+\\s(on[a-z]+)=[^>]+>"),
-            "Inline Script Block", Pattern.compile("<script.*>.*\\S+.*</script>"),
+            "Inline Script Block", Pattern.compile("(<script>|<script[^>]*[^/]>).*?\\S.*?</script>", Pattern.DOTALL),
             "Legacy checkUrl", Pattern.compile("(checkUrl=\"[^\"]*'[^\"]*'[^\"]*\")|(checkUrl='[^']*\"[^']*\"[^']*')"));
 
     /**

--- a/src/test/java/io/jenkins/security/csp/ScannerTest.java
+++ b/src/test/java/io/jenkins/security/csp/ScannerTest.java
@@ -4,10 +4,15 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 
 public class ScannerTest {
     @Test
@@ -20,12 +25,32 @@ public class ScannerTest {
                 "checkUrl=\"'descriptorByName/hudson.tasks.test.AggregatedTestResultPublisher/check?value='+encodeURIComponent(this.value)\"");
     }
 
-    private static void assertMatch(String haystack, Map<String, Pattern> patterns, String match) {
+    @Test
+    public void issues3_4_5() {
+        final String scriptBlock = "<script>\nfoo bar\n baz \n</script>";
+        assertMatch(scriptBlock, Scanner.JELLY_PATTERNS, scriptBlock);
+        assertMatch("<some><wrapper>\n" + scriptBlock + "\n</wrapper></some>", Scanner.JELLY_PATTERNS, scriptBlock);
+
+        assertMatches("<some><wrapper>\n" + scriptBlock + "\n" + scriptBlock + "</wrapper></some>", Scanner.JELLY_PATTERNS, List.of(scriptBlock, scriptBlock));
+
+        assertNoMatch("<foo><script src='whatever'/></foo>", Scanner.JELLY_PATTERNS);
+        assertMatch("<foo><script src='whatever' />" + scriptBlock + "</foo>", Scanner.JELLY_PATTERNS, scriptBlock);
+    }
+
+    private static void assertMatch(String haystack, Map<String, Pattern> patterns, String expectedMatch) {
         final File dummy = new File("dummy");
         final List<Scanner.Match> matches = Scanner.matchRegexes(patterns, haystack, dummy);
         assertThat(matches.size(), is(1));
         final Scanner.Match matchEntry = matches.get(0);
-        assertThat(matchEntry.match, is(match));
+        assertThat(matchEntry.match, is(expectedMatch));
+    }
+
+    private static void assertMatches(String haystack, Map<String, Pattern> patterns, List<String> expectedMatches) {
+        final File dummy = new File("dummy");
+        final List<Scanner.Match> matches1 = Scanner.matchRegexes(patterns, haystack, dummy);
+        assertThat(expectedMatches.size(), is(expectedMatches.size()));
+        final List<String> actualMatches = matches1.stream().map(m -> m.match).collect(Collectors.toList());
+        assertThat(actualMatches, contains(expectedMatches.stream().map(CoreMatchers::is).collect(Collectors.toList())));
     }
 
     private static void assertNoMatch(String haystack, Map<String, Pattern> patterns) {


### PR DESCRIPTION
Fixes #3, fixes #4, fixes #5.