### PR TITLE
Add rudimentary support for .java, .html, .properties files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,5 +21,5 @@ java -jar target/csp-scanner.jar /home/daniel/code/jenkins/*/src/main/resources/
 
 == Limitations
 
-* This tool currently only identifies problematic patterns in `.jelly` and `.js` files.
+* This tool currently only identifies problematic patterns in `.jelly`/`.java`/`.html`/`.properties` and `.js` files.
   Groovy views are unsupported.

--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -118,7 +118,7 @@ public class Scanner {
     private static void printMatches(List<Match> matches) {
         matches.forEach(match -> {
             System.out.println("== " + match.title);
-            System.out.println("File: " + match.file.toPath());
+            System.out.println("File: " + match.file.toPath() + " +");
             System.out.println("Line: " + match.line);
             System.out.println("----");
             System.out.println(match.match);

--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -31,6 +31,9 @@ public class Scanner {
     // geval is defined in hudson-behavior.js
     protected static final Map<String, Pattern> JS_PATTERNS = Map.of("(g)eval Call", Pattern.compile("\\Wg?eval\\W"));
 
+    protected static final Map<String, Pattern> JAVA_PATTERNS = Map.of("Inline Event Handler (Java)", Pattern.compile("((?<!\\\\)\")[^\"]*(?<![a-z0-9A-Z])(on[a-z]{3,20})=.*?((?<!\\\\)\")"),
+            "Inline Script Block (Java)", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?(?<!<script[^>]{0,1000}>)</script>", Pattern.DOTALL));
+
     protected static class Match {
         protected final String title;
         protected final String match;
@@ -81,12 +84,18 @@ public class Scanner {
     }
 
     private static void visitFile(File file) throws IOException {
-        if (file.getName().endsWith(".jelly")) {
+        final String fileName = file.getName();
+        if (fileName.endsWith(".jelly") || fileName.endsWith(".html") || fileName.endsWith(".properties")) {
             final String text = Files.readString(file.toPath());
             printMatches(matchRegexes(JELLY_PATTERNS, text, file));
         }
 
-        if (file.getName().endsWith(".js")) {
+        if (fileName.endsWith(".java")) {
+            final String text = Files.readString(file.toPath());
+            printMatches(matchRegexes(JAVA_PATTERNS, text, file));
+        }
+
+        if (fileName.endsWith(".js")) {
             final String text = Files.readString(file.toPath());
             printMatches(matchRegexes(JS_PATTERNS, text, file));
         }

--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -24,7 +24,7 @@ public class Scanner {
      * Patterns identified in .jelly files
      */
     protected static final Map<String, Pattern> JELLY_PATTERNS = Map.of("Inline Event Handler", Pattern.compile("<[^>]+\\s" + JS_EVENT_ATTRIBUTES + "=[^>]+>", Pattern.CASE_INSENSITIVE),
-            "Inline Script Block", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
+            "Inline Script Block", Pattern.compile("(<script>|<script(|\\s[^>]*)[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
             "Legacy checkUrl", Pattern.compile("(checkUrl=\"[^\"]*'[^\"]*'[^\"]*\")|(checkUrl='[^']*\"[^']*\"[^']*')", Pattern.CASE_INSENSITIVE));
 
     /**
@@ -36,7 +36,7 @@ public class Scanner {
     protected static final Map<String, Pattern> JS_PATTERNS = Map.of("(g)eval Call", Pattern.compile("\\Wg?eval\\W"));
 
     protected static final Map<String, Pattern> JAVA_PATTERNS = Map.of("Inline Event Handler (Java)", Pattern.compile("(?<![a-z0-9])" + JS_EVENT_ATTRIBUTES + "=.*?((?<!\\\\)\")", Pattern.CASE_INSENSITIVE),
-            "Inline Script Block (Java)", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
+            "Inline Script Block (Java)", Pattern.compile("(<script>|<script(|\\s[^>]*)[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
             "FormApply#applyResponse", Pattern.compile("FormApply[.]applyResponse[(].*"));
 
     protected static class Match {

--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -15,13 +15,14 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class Scanner {
+    private static final String JS_EVENT_ATTRIBUTES = "(on(auxclick|beforeinput|beforematch|beforetoggle|blur|cancel|canplay|canplaythrough|change|click|close|contextlost|contextmenu|contextrestored|copy|cuechange|cut|dblclick|drag|dragend|dragenter|dragleave|dragover|dragstart|drop|durationchange|emptied|ended|error|focus|formdata|input|invalid|keydown|keypress|keyup|load|loadeddata|loadedmetadata|loadstart|mousedown|mouseenter|mouseleave|mousemove|mouseout|mouseover|mouseup|paste|pause|play|playing|progress|ratechange|reset|resize|scroll|scrollend|securitypolicyviolation|seeked|seeking|select|slotchange|stalled|submit|suspend|timeupdate|toggle|volumechange|waiting|wheel))";
+
     /**
      * Patterns identified in .jelly files
      */
-    protected static final Map<String, Pattern> JELLY_PATTERNS = Map.of("Inline Event Handler", Pattern.compile("<[^>]+\\s(on[a-z]+)=[^>]+>"),
-            // Experimentally, the lookbehind is only relevant in syntactically invalid-ish files (layout/layout.jelly), but doesn't break anything either
-            "Inline Script Block", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?(?<!<script[^>]{0,1000}>)</script>", Pattern.DOTALL),
-            "Legacy checkUrl", Pattern.compile("(checkUrl=\"[^\"]*'[^\"]*'[^\"]*\")|(checkUrl='[^']*\"[^']*\"[^']*')"));
+    protected static final Map<String, Pattern> JELLY_PATTERNS = Map.of("Inline Event Handler", Pattern.compile("<[^>]+\\s" + JS_EVENT_ATTRIBUTES + "=[^>]+>", Pattern.CASE_INSENSITIVE),
+            "Inline Script Block", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
+            "Legacy checkUrl", Pattern.compile("(checkUrl=\"[^\"]*'[^\"]*'[^\"]*\")|(checkUrl='[^']*\"[^']*\"[^']*')", Pattern.CASE_INSENSITIVE));
 
     /**
      * Patterns identified in .js files
@@ -31,8 +32,8 @@ public class Scanner {
     // geval is defined in hudson-behavior.js
     protected static final Map<String, Pattern> JS_PATTERNS = Map.of("(g)eval Call", Pattern.compile("\\Wg?eval\\W"));
 
-    protected static final Map<String, Pattern> JAVA_PATTERNS = Map.of("Inline Event Handler (Java)", Pattern.compile("((?<!\\\\)\")[^\"]*(?<![a-z0-9A-Z])(on[a-z]{3,20})=.*?((?<!\\\\)\")"),
-            "Inline Script Block (Java)", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?(?<!<script[^>]{0,1000}>)</script>", Pattern.DOTALL));
+    protected static final Map<String, Pattern> JAVA_PATTERNS = Map.of("Inline Event Handler (Java)", Pattern.compile("(?<![a-z0-9])" + JS_EVENT_ATTRIBUTES + "=.*?((?<!\\\\)\")", Pattern.CASE_INSENSITIVE),
+            "Inline Script Block (Java)", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE));
 
     protected static class Match {
         protected final String title;

--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -33,7 +33,8 @@ public class Scanner {
     protected static final Map<String, Pattern> JS_PATTERNS = Map.of("(g)eval Call", Pattern.compile("\\Wg?eval\\W"));
 
     protected static final Map<String, Pattern> JAVA_PATTERNS = Map.of("Inline Event Handler (Java)", Pattern.compile("(?<![a-z0-9])" + JS_EVENT_ATTRIBUTES + "=.*?((?<!\\\\)\")", Pattern.CASE_INSENSITIVE),
-            "Inline Script Block (Java)", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE));
+            "Inline Script Block (Java)", Pattern.compile("(<script>|<script[^>]*[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
+            "FormApply#applyResponse", Pattern.compile("FormApply[.]applyResponse[(].*"));
 
     protected static class Match {
         protected final String title;

--- a/src/test/java/io/jenkins/security/csp/ScannerTest.java
+++ b/src/test/java/io/jenkins/security/csp/ScannerTest.java
@@ -90,6 +90,8 @@ public class ScannerTest {
                 "      <script type=\"text/javascript\" src=\"${request.contextPath}/plugin/rusalad-plugin/scripts/rusalad/rusalad.js\">foo</script>",
                 Scanner.JELLY_PATTERNS,
                 "<script type=\"text/javascript\" src=\"${request.contextPath}/plugin/rusalad-plugin/scripts/rusalad/rusalad.js\">foo</script>");
+
+        assertNoMatch("<ScriptApproval>.........</script>", Scanner.JELLY_PATTERNS);
     }
 
     private static void assertMatch(String haystack, Map<String, Pattern> patterns, String expectedMatch) {

--- a/src/test/java/io/jenkins/security/csp/ScannerTest.java
+++ b/src/test/java/io/jenkins/security/csp/ScannerTest.java
@@ -16,6 +16,13 @@ import static org.hamcrest.Matchers.contains;
 
 public class ScannerTest {
     @Test
+    public void issue1() {
+        assertMatch("return \" onclick=\\\"fetch(decodeURIComponent(atob('\" + encodeForJavascript(url) + \"')), { method: 'post', headers: crumb.wrap({})}); return false\\\"\";",
+                Scanner.JAVA_PATTERNS,
+                "\" onclick=\\\"fetch(decodeURIComponent(atob('\"");
+    }
+
+    @Test
     public void issue2() {
         assertMatch("<f:textbox name=\"aggregatedTestResult.jobs\" value=\"${instance.jobs}\"\n" +
                 "checkUrl=\"'descriptorByName/hudson.tasks.test.AggregatedTestResultPublisher/check?value='+encodeURIComponent(this.value)\"\n" +

--- a/src/test/java/io/jenkins/security/csp/ScannerTest.java
+++ b/src/test/java/io/jenkins/security/csp/ScannerTest.java
@@ -19,7 +19,13 @@ public class ScannerTest {
     public void issue1() {
         assertMatch("return \" onclick=\\\"fetch(decodeURIComponent(atob('\" + encodeForJavascript(url) + \"')), { method: 'post', headers: crumb.wrap({})}); return false\\\"\";",
                 Scanner.JAVA_PATTERNS,
-                "\" onclick=\\\"fetch(decodeURIComponent(atob('\"");
+                "onclick=\\\"fetch(decodeURIComponent(atob('\"");
+
+        assertMatch("\"<div class=\\\"collapseAction\\\"><p onClick=\\\"doToggle(this)\\\">\"", Scanner.JAVA_PATTERNS, "onClick=\\\"doToggle(this)\\\">\"");
+
+        assertMatch("text.addMarkup(0, 0, \"\", \"<div class=\\\"section\\\" data-level=\\\"\"+getCurrentLevelPrefix()+\"\\\"><div class=\\\"collapseHeader\\\">\" + getCurrentLevelPrefix() + Util.escape(section.getSectionDisplayName(m)) + \"<div class=\\\"collapseAction\\\"><p onClick=\\\"doToggle(this)\\\">\" + ((section.isCollapseSection()) ? \"Show Details\" : \"Hide Details\") +\"</p></div></div><div class=\\\"\" + ((section.isCollapseSection()) ? \"collapsed\" : \"expanded\") + \"\\\">\");",
+                Scanner.JAVA_PATTERNS,
+                "onClick=\\\"doToggle(this)\\\">\"");
     }
 
     @Test


### PR DESCRIPTION
Mostly fixes #1.

Identifies:

* https://github.com/jenkinsci/workflow-support-plugin/blob/f8d41ac42279d1811b81b0afb5e6e2e4b95843fe/src/main/java/org/jenkinsci/plugins/workflow/support/steps/input/POSTHyperlinkNote.java#L86 (the test case)
* https://github.com/jenkinsci/jenkins/blob/e1a6b190d4d71e95a8e00facd52ce7718909b9e8/core/src/main/java/hudson/util/ListBoxModel.java#L73-L75 (OK to find IMO)
* https://github.com/jenkinsci/collapsing-console-sections-plugin/blob/5685b78d0defbe4783f82d4dcf68bc1bde63f327/src/main/java/org/jvnet/hudson/plugins/collapsingconsolesections/CollapsingSectionAnnotator.java#L107 (for #11)

… and a bunch of stuff in test sources.