### PR TITLE
Match inline event handlers in JavaScript files

### DIFF
--- a/src/main/java/io/jenkins/security/csp/Scanner.java
+++ b/src/main/java/io/jenkins/security/csp/Scanner.java
@@ -36,7 +36,9 @@ public class Scanner {
     // Examples indicate trying to match open-paren would be too restrictive:
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval
     // geval is defined in hudson-behavior.js
-    protected static final Map<String, Pattern> JS_PATTERNS = Map.of("(g)eval Call", Pattern.compile("\\Wg?eval\\W"));
+    protected static final Map<String, Pattern> JS_PATTERNS = Map.of("(g)eval Call", Pattern.compile("\\Wg?eval\\W"),
+            "Inline Event Handler (JavaScript)", Pattern.compile("[\\s+]" + JS_EVENT_ATTRIBUTES + ".*?((?<!\\\\)['\"]?)[_\\w]+\\s*\\(", Pattern.CASE_INSENSITIVE),
+            "Javascript scheme (JavaScript)", Pattern.compile("\".*(?<![a-z0-9])javascript:.*?((?<!\\\\)\")", Pattern.CASE_INSENSITIVE));
 
     protected static final Map<String, Pattern> JAVA_PATTERNS = Map.of("Inline Event Handler (Java)", Pattern.compile("(?<![a-z0-9])" + JS_EVENT_ATTRIBUTES + "=.*?((?<!\\\\)\")", Pattern.CASE_INSENSITIVE),
             "Inline Script Block (Java)", Pattern.compile("(<script>|<script(|\\s[^>]*)[^/]>)\\s*?(?!</script>)\\S.*?</script>", Pattern.DOTALL | Pattern.CASE_INSENSITIVE),
@@ -123,7 +125,7 @@ public class Scanner {
 
         if (fileName.endsWith(".java")) {
             final String text = readFileToString(file);
-            printMatches(matchRegexes(JAVA_PATTERNS, text, file));
+            matches.addAll(matchRegexes(JAVA_PATTERNS, text, file));
         }
 
         if (fileName.endsWith(".js")) {

--- a/src/test/java/io/jenkins/security/csp/ScannerTest.java
+++ b/src/test/java/io/jenkins/security/csp/ScannerTest.java
@@ -116,6 +116,30 @@ public class ScannerTest {
         assertMatch(doubleQuote, Scanner.JAVA_PATTERNS, doubleQuote);
     }
 
+    @Test
+    public void javascriptSchemeInJavaScriptFiles() {
+        String doubleQuote = "\"<a href=\\\"javascript:randomJavaScript\\\">\"";
+        String simpleQuote = "\"<a href='javascript:randomJavaScript'>\"";
+        String noQuote = "\"<a href=javascript:randomJavaScript>\"";
+
+        assertMatch(noQuote, Scanner.JS_PATTERNS, noQuote);
+        assertMatch(simpleQuote, Scanner.JS_PATTERNS, simpleQuote);
+        assertMatch(doubleQuote, Scanner.JS_PATTERNS, doubleQuote);
+    }
+
+    @Test
+    public void inlineHandlersInJavaScriptFiles() {
+        String doubleQuote = "html.push('<div class=\"task-manual\" id=\"manual-' + id + '\" title=\"Trigger manual build\" onCliCk=\"invokeMe(\\'trigger\\')\">');";
+        String singleQuote = "html.push('<div class=\"task-manual\" id=\"manual-' + id + '\" title=\"Trigger manual build\" onclick='invokeMe(\\'trigger\\')'>');";
+        String noQuote = "html.push('<div class=\"task-manual\" id=\"manual-' + id + '\" title=\"Trigger manual build\" onclick=invokeMe(\\'trigger\\')>');";
+        String noMatch = "document.onload=function(){ console.log(1) }";
+
+        assertMatch(doubleQuote, Scanner.JS_PATTERNS, " onCliCk=\"invokeMe(");
+        assertMatch(singleQuote, Scanner.JS_PATTERNS, " onclick='invokeMe(");
+        assertMatch(noQuote, Scanner.JS_PATTERNS, " onclick=invokeMe(");
+        assertNoMatch(noMatch, Scanner.JS_PATTERNS);
+    }
+
     private static void assertMatch(String haystack, Map<String, Pattern> patterns, String expectedMatch) {
         final File dummy = new File("dummy");
         final List<Scanner.Match> matches = Scanner.matchRegexes(patterns, haystack, dummy);


### PR DESCRIPTION
Addresses https://github.com/daniel-beck/csp-scanner/issues/16.

Known limitation:
If JavaScript is poorly formatted may result in false positives. E.g. `document. onload=function(){}` will get matched.